### PR TITLE
fix: missing HikariCP on UNIX os

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,10 +135,11 @@ afterEvaluate {
         group = 'build'
         description = 'Merges the Fabric and Paper jars into one combined jar'
 
-        dependsOn(tasks.named('signFabricJar')) // Ensure signing happens before merging
+        dependsOn(tasks.named('signFabricJar'))
+        dependsOn(project(':paper').tasks.named('shadowJar'))
 
         def signedJarProvider = tasks.named('signFabricJar').flatMap { it.outputs.files.elements.map { fs -> fs.first().asFile } }
-        def paperJarProvider = project(':paper').tasks.named('jar').flatMap { it.archiveFile }
+        def paperJarProvider = project(':paper').tasks.named('shadowJar').flatMap { it.archiveFile }
 
         from(signedJarProvider.map { file -> zipTree(file) })
         from(paperJarProvider.map { file -> zipTree(file) }) {

--- a/paper/build.gradle
+++ b/paper/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
 group = 'me.mklv'
@@ -37,6 +38,26 @@ processResources {
     dependsOn rootProject.tasks.named('copyCert')
     filteringCharset = 'UTF-8'
     filesMatching('plugin.yml') { expand(version: project.version) }
+}
+
+shadowJar {
+    archiveClassifier.set('')
+
+    relocate 'com.zaxxer.hikari', 'me.mklv.handshaker.libs.hikari'
+    relocate 'org.sqlite', 'me.mklv.handshaker.libs.sqlite'
+    relocate 'org.slf4j', 'me.mklv.handshaker.libs.slf4j'
+
+    dependencies {
+        exclude(dependency('io.papermc.paper:paper-api'))
+    }
+}
+
+jar {
+    enabled = false
+}
+
+tasks.named('assemble') {
+    dependsOn shadowJar
 }
 
 publishing {


### PR DESCRIPTION
Resolves the plugin loading failure on Purpur servers caused by missing HikariCP classes.

## Changes
- Added Gradle Shadow plugin to shade database dependencies (HikariCP, SQLite, SLF4J) into the Paper JAR
- Configured dependency relocation to `me.mklv.handshaker.libs.*` to prevent conflicts
- Updated build configuration to use shadowJar instead of nested JAR packaging

## Context
Purpur's classloader does not load nested JARs from `META-INF/jars/`. Shading dependencies directly into the JAR resolves the `NoClassDefFoundError: com/zaxxer/hikari/HikariConfig` error.

Fixes #7